### PR TITLE
Mention Overlay Fixes

### DIFF
--- a/src/element/Mentions/component/MentionOverlay.svelte
+++ b/src/element/Mentions/component/MentionOverlay.svelte
@@ -43,6 +43,7 @@
 	import {
 		createEventDispatcher,
 		onMount,
+		tick,
 	} from 'svelte';
 
 	import {
@@ -77,7 +78,8 @@ import { SI_EDITOR_SYNC_KEY } from '#/vendor/confluence/module/confluence';
 	let dm_content!: HTMLDivElement;
 
 	const f_dispatch = createEventDispatcher();
-	onMount(() => {
+	onMount(async() => {
+		await tick();
 		f_dispatch('dom', {
 			dm_container,
 			dm_content,
@@ -121,7 +123,7 @@ import { SI_EDITOR_SYNC_KEY } from '#/vendor/confluence/module/confluence';
 	}
 
 
-	function select_row(g_attr?: ValuedLabeledObject<string>) {
+	function select_row() {
 		const dm_selected = qs(dm_content, '.item-selected');
 
 		if(!dm_selected) {
@@ -132,7 +134,7 @@ import { SI_EDITOR_SYNC_KEY } from '#/vendor/confluence/module/confluence';
 			return select_item(dm_selected);
 		}
 		else if(DisplayMode.ATTRIBUTE === xc_mode) {
-			return select_attribute(g_attr!);
+			return select_attribute(a_attributes[parseInt(dm_selected.getAttribute('data-index')!)]);
 		}
 	}
 
@@ -405,7 +407,7 @@ import { SI_EDITOR_SYNC_KEY } from '#/vendor/confluence/module/confluence';
 		{/if}
 	</div>
 
-	{#if DisplayMode.ITEM === xc_mode}
+	<!--{#if DisplayMode.ITEM === xc_mode}
 		<div class="filter-select-scrollable">
 			<div class="filter-select">
 				<span class="filter selected" data-channel-all=1 on:click={() => enable_all_channels()}>
@@ -422,7 +424,7 @@ import { SI_EDITOR_SYNC_KEY } from '#/vendor/confluence/module/confluence';
 				</span>
 			</div>
 		</div>
-	{/if}
+	{/if} -->
 
 	<div class="filter-content-scrollable">
 		<div class="filter-content">
@@ -455,12 +457,13 @@ import { SI_EDITOR_SYNC_KEY } from '#/vendor/confluence/module/confluence';
 						</div>
 					{/each}
 				{:else if DisplayMode.ATTRIBUTE === xc_mode}
-					{#each a_attributes as g_attr, i_attr}
-						<div class="group">
+					<div class="group">
+						{#each a_attributes as g_attr, i_attr}
 							<div class="row"
+								data-index={i_attr}
 								on:mouseenter={mouseenter_row}
 								on:mouseleave={mouseleave_row}
-								on:click={() => select_row(g_attr)}
+								on:click={select_row}
 								class:item-selected={!i_attr}
 							>
 								<span class="info">
@@ -472,8 +475,8 @@ import { SI_EDITOR_SYNC_KEY } from '#/vendor/confluence/module/confluence';
 									</div>
 								</span>
 							</div>
-						</div>
-					{/each}
+						{/each}
+					</div>
 				{/if}
 			</div>
 		</div>

--- a/src/element/Mentions/model/Mention.ts
+++ b/src/element/Mentions/model/Mention.ts
@@ -817,9 +817,9 @@ export class Mention {
 		});
 
 		// listen for dom init event to fetch dom refs
-		this._y_component.$on('dom', ({dm_container, dm_content}: {dm_container: HTMLElement; dm_content: HTMLElement}) => {
-			this._dm_overlay_container = dm_container;
-			this._dm_overlay_content = dm_content;
+		this._y_component.$on('dom', (d_event: CustomEvent<{dm_container: HTMLElement; dm_content: HTMLElement}>) => {
+			this._dm_overlay_container = d_event.detail.dm_container;
+			this._dm_overlay_content = d_event.detail.dm_content;
 		});
 
 		return true;


### PR DESCRIPTION
 * Comment-out the filter tabs in the mention overlay box
   * Interacting with the filter tabs causes the text cursor to disappear; until we figure out a fix for this
     don't display them (they currently don't do anything).
 * Fix Enter key handling to allow selecting an item after using arrow keys to navigate through items.
   * The `Mention` class wasn't able to capture the `MentionOverlay` DOM nodes because the `dom` event was being
     fired before the listener was attached; as a workaround `MentionOverlay` now dispatches the event asynchronously
     after waiting for a `tick()`. Additionally, the `dom` event data wasn't being extracted correctly.
 * Allow using arrow and enter keys to select an Attribute after selecting an Item
   * Navigation using the arrow keys wasn't working because the attribute rows weren't direct siblings of each other;
     this restructures the DOM to put all attribute rows in the same group DIV
   * Selection with Enter wasn't working because selecting an attribute required the attribute object to be passed
     from the event listener, which isn't possible from the Enter key handler. To work around this we instead keep
     track of the item index in the DOM node and use that to find the required attribute object.